### PR TITLE
add a class to manage bcrypt gem

### DIFF
--- a/examples/bcrypt.pp
+++ b/examples/bcrypt.pp
@@ -1,3 +1,5 @@
+include bcrypt
+
 $plaintext = 'foobar'
 $bcryptpasswd = bcrypt($plaintext)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,11 @@
+# Include this class to install the bcrypt gem
+class bcrypt (
+  $manage_bcrypt = true,
+) {
+  if $manage_bcrypt {
+    package { 'bcrypt':
+      ensure   => 'installed',
+      provider => 'puppet_gem',
+    }
+  }
+}


### PR DESCRIPTION
in order to use this module, we need the bcrypt gem in our puppet
installations. This adds a convenience class to do exactly that.